### PR TITLE
deleting the define of namespcae

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Support\Facades\Route;
 
-define('NAMESPACE', '');
-
 /*
 |--------------------------------------------------------------------------
 | Tool API Routes


### PR DESCRIPTION
could we delete namespace define because when trying to cache routes it gives an error
`ErrorException  : Constant NAMESPACE already defined`