### PR TITLE
Use name config in select query

### DIFF
--- a/src/Library/UserUtility.php
+++ b/src/Library/UserUtility.php
@@ -56,7 +56,7 @@ class UserUtility
         $selectQuery = [ 'id', config('novaemailsender.model.email') ];
 
         if (!empty(config('novaemailsender.model.name'))) {
-            $selectQuery[] = 'name';
+            $selectQuery[] = config('novaemailsender.model.name');
         } else {
             $selectQuery[] = config('novaemailsender.model.first_name');
             $selectQuery[] = config('novaemailsender.model.last_name');


### PR DESCRIPTION
Fix for:
https://github.com/dniccum/nova-custom-email-sender/issues/9

I've tested it with the following config:
'model' => [
        'class' => \App\User::class,
        'email' => 'email',
        'name' => 'email',
        'first_name' => null,
        'last_name' => null,
],